### PR TITLE
fix: update publishVersion

### DIFF
--- a/src/main/g8/build.sc
+++ b/src/main/g8/build.sc
@@ -28,15 +28,7 @@ object plugin
 
   override def scalaVersion = scala213
 
-  override def publishVersion = VcsVersion
-    .vcsState()
-    .format(
-      tagModifier = {
-        case t if t.startsWith("v") && Try(t.substring(1, 2).toInt).isSuccess =>
-          t.substring(1)
-        case t => t
-      }
-    )
+  override def publishVersion = VcsVersion.vcsState().format()
 
   override def pomSettings = PomSettings(
     description = "$description$",


### PR DESCRIPTION
With 0.1.1 of mill-vcs-version the leading v wasn't stripped by default.
Now with the latest 0.2.0 it is, so we don't have to have this extra
logic in here.
